### PR TITLE
feat: Custom ACF Jetforms select

### DIFF
--- a/src/Support/Acf.php
+++ b/src/Support/Acf.php
@@ -104,6 +104,9 @@ abstract class Acf
     public function generateKeys(array $fields, $prefix)
     {
         foreach ($fields as $key => $field) {
+			if ($field['type'] == 'jetforms') {
+				$field = JetformsFieldGenerator::generate($field);
+			}
             $fields[$key] = $this->generateKey($field, $prefix);
         }
 

--- a/src/Support/JetformsFieldGenerator.php
+++ b/src/Support/JetformsFieldGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace OutlawzTeam\Radicle\Support;
+
+class JetformsFieldGenerator
+{
+	public static function generate(array $field)
+	{
+		// Initialize choices array
+		$choices = [];
+
+		// Fetch jetforms and generate choices
+		$jetforms = get_posts([
+			'post_type' => 'jet-form-builder',
+			'posts_per_page' => -1,
+		]);
+
+		foreach ($jetforms as $jetform) {
+			$form_id = $jetform->ID;
+			$meta_json = get_post_meta($form_id, '_jf_args', true);
+
+			$default_attributes = [
+				'submit_type' => '',
+				'required_mark' => '',
+				'fields_layout' => '',
+				'enable_progress' => null,
+				'fields_label_tag' => '',
+				'load_nonce' => '',
+				'use_csrf' => '',
+			];
+
+			$meta = empty($meta_json) ? $default_attributes : json_decode($meta_json, true);
+
+			$shortcode = '[jet_fb_form form_id="' . $form_id . '"';
+			foreach ($meta as $key => $value) {
+				if ($key === 'form_id') {
+					continue;
+				}
+				$value = $value === null ? '' : $value;
+				$shortcode .= sprintf(' %s="%s"', $key, esc_attr($value));
+			}
+			$shortcode .= ']';
+			$choices[$shortcode] = $jetform->post_title;
+		}
+
+		// Set the field to select and assign the generated choices
+		$field['type'] = 'select';
+		$field['choices'] = $choices;
+
+		return $field;
+	}
+}


### PR DESCRIPTION
This PR creates a new ACF field "type" named "jetforms". This component will be presented on the UI as a select of which the options are all the jetforms. The developer can then acces the shortcode of the form a user selected by the key of the value. 

To construct the shortcode we ofcourse use the form post ID. If any of the form settings are altered, for example setting the submit type to ajax, a row will be inserted in post_meta with key "_jf_args". We decode the jason value and construct the shortcode using the attributes we decoded. 

If no form settings were changed there won't be a post_meta row for the form. We fall back on some default attributes that I observed are present in all form shortcodes (in the jetform overview UI) that don't have altered form settings. 

TODO: It would probably be wise to check wether the jetform plugin is active and if 
`$jetforms = get_posts([
			'post_type' => 'jet-form-builder',
			'posts_per_page' => -1,
]);`
returns any results.